### PR TITLE
Allow to use text elements for section text field

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ SlackBuilder.message do
       image 'https://media.giphy.com/media/cYNjbM2MvPzM8raKvh/giphy.gif', alt_text: 'Bar'
     end
   end
+  section do
+    text do
+      plain_text 'Hello world :wave:'
+    end
+    mrkdwn '*Priority*'
+    mrkdwn '*Critical*'
+    plain_text 'High :collision:'
+    plain_text '¯\\_(ツ)_/¯', emoji: false
+    accessory do
+      image 'https://media.giphy.com/media/AcfTF7tyikWyroP0x7/giphy.gif', alt_text: 'Baz'
+    end
+  end
   video 'https://www.youtube.com/watch?v=PdaAHMztNVE', thumbnail_url: 'https://media.giphy.com/media/cYNjbM2MvPzM8raKvh/giphy.gif', alt_text: 'Foo', title: 'Bar :collision:'
   divider
   rich_text do

--- a/lib/slack_builder/elements/section.rb
+++ b/lib/slack_builder/elements/section.rb
@@ -33,6 +33,24 @@ module SlackBuilder
         end
       end
 
+      class Text
+        private_class_method :new
+
+        def self.build(&blk)
+          new.instance_exec(&blk)
+        end
+
+        private
+
+        def mrkdwn(...)
+          TextElements::Markdown.new(...)
+        end
+
+        def plain_text(...)
+          TextElements::PlainText.new(...)
+        end
+      end
+
       def initialize(text = nil, verbatim: false, **kwargs, &blk)
         @text = TextElements::Markdown.new(text, verbatim: verbatim) unless text.nil?
         super(**kwargs, &blk)
@@ -48,6 +66,10 @@ module SlackBuilder
 
       def accessory(...)
         @accessory = Accessory.build(...) if block_given?
+      end
+
+      def text(...)
+        @text = Text.build(...) if block_given?
       end
 
       def mrkdwn(...)

--- a/spec/slack_builder/elements/section_spec.rb
+++ b/spec/slack_builder/elements/section_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SlackBuilder::Elements::Section do
 
     it { is_expected.to eq(expected_attributes) }
 
-    context 'with a text' do
+    context 'with a text provided as argument' do
       let(:element) { described_class.new('Hello world', verbatim: true, &blocks) }
 
       let(:expected_attributes) do
@@ -49,6 +49,34 @@ RSpec.describe SlackBuilder::Elements::Section do
             type: 'mrkdwn',
             text: 'Hello world',
             verbatim: true,
+          },
+          fields: expected_blocks,
+        }
+      end
+
+      it { is_expected.to eq(expected_attributes) }
+    end
+
+    context 'with a text defined as block' do
+      let(:blocks) do
+        proc do
+          text do
+            mrkdwn 'Foo', verbatim: true
+            plain_text 'Bar', emoji: false
+          end
+
+          plain_text 'Hello'
+          mrkdwn 'World'
+        end
+      end
+
+      let(:expected_attributes) do
+        {
+          type: 'section',
+          text: {
+            type: 'plain_text',
+            text: 'Bar',
+            emoji: false,
           },
           fields: expected_blocks,
         }


### PR DESCRIPTION
## What?

Allow to set [Section](https://api.slack.com/reference/block-kit/blocks#section) text field with [text elements](https://api.slack.com/reference/block-kit/composition-objects#text).

#### Before

```ruby
section '*Hello* world :wave:'
```
```json
{
  "type": "section",
  "text": {
    "type": "mrkdwn",
    "text": "*Hello* world :wave:",
    "verbatim": false
  }
}
```

#### After


```ruby
section do
  text do
    plain_text 'Hello world :wave:'
  end
end
```
```json
{
  "type": "section",
  "text": {
    "type": "plain_text",
    "text": "Hello world :wave:",
    "emoji": true
  }
}
```


## Why?

- Was initially implemented using `mrkdwn` object when provided as argument.
- Allow to optionally use `plain_text` object as mentioned in the [documentation](https://api.slack.com/reference/block-kit/blocks#section).

